### PR TITLE
修改是否只能显示系统样式的Toast判断

### DIFF
--- a/library/src/main/java/com/hjq/toast/ToastStrategy.java
+++ b/library/src/main/java/com/hjq/toast/ToastStrategy.java
@@ -253,8 +253,8 @@ public class ToastStrategy implements IToastStrategy {
      */
     protected boolean onlyShowSystemToastStyle() {
         // Github issue 地址：https://github.com/getActivity/Toaster/issues/103
-        // Toast.CHANGE_TEXT_TOASTS_IN_THE_SYSTEM = 147798919L
-        return isChangeEnabledCompat(147798919L);
+        // NotificationManagerService.CHANGE_BACKGROUND_CUSTOM_TOAST_BLOCK = 128611929L
+        return isChangeEnabledCompat(128611929L);
     }
 
     @SuppressLint("PrivateApi")


### PR DESCRIPTION
严格说来应该使用NotificationManagerService.CHANGE_BACKGROUND_CUSTOM_TOAST_BLOCK来判断是否只能显示系统样式的Toast,它是NotificationManagerService在显示Toast时,用判断是否Block的的条件.虽然实际上这两个值是一样的. 但在测试兼容性时,通过adb shell am compat disable
CHANGE_BACKGROUND_CUSTOM_TOAST_BLOCK com.hjq.toast.demo 禁用后,是可以在后台显示自定义toast的.这样会更准确. 另外,在实际使用中在Android R及以上这个值,正常来说是True的,这里是否有必要还通过反射去调用判断值,直接判断是否>=Android R就可以了.